### PR TITLE
Build with Java 21 as well

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [11, 17]
+        jdk: [11, 17, 21]
         include:
           # lengthy build steps should only be performed on linux with Java 11 (SonarQube analysis, deployment)
           - os: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # always act on the modified source code (even for event pull_request_target)
         # is considered potentially unsafe (https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) but actions are only executed after approval from committers
         with:


### PR DESCRIPTION
Wait for https://github.com/adoptium/temurin/issues/7 (Temurin 21 release)